### PR TITLE
Add rqrcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ that the library allows to generate QR codes.
 - [sylnsfar/qrcode `W`](https://github.com/sylnsfar/qrcode) - Artistic QR code in Python (can produce GIFs).
 
 ### Ruby
-- [rqrcode `W`](https://github.com/whomwah/rqrcode) - A neat Ruby QR code generator exporting to `svg`, `png` and `ansi` with configurable size, colour and other attributes.
+- [rqrcode `W`](https://github.com/whomwah/rqrcode) - A neat Ruby QR code generator exporting to `svg`, `png` and `ansi` with configurable size, color and other attributes.
 
 ### Objective-C
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ that the library allows to generate QR codes.
 
 - [sylnsfar/qrcode `W`](https://github.com/sylnsfar/qrcode) - Artistic QR code in Python (can produce GIFs).
 
+### Ruby
+- [rqrcode `W`](https://github.com/whomwah/rqrcode) - A neat Ruby QR code generator exporting to `svg`, `png` and `ansi` with configurable size, colour and other attributes.
+
 ### Objective-C
 
 - [SGQRCode `R`](https://github.com/kingsic/SGQRCode) - Easy to use QR code scan library for iOS.


### PR DESCRIPTION
### What
Add Ruby [rqrcode](https://github.com/whomwah/rqrcode) library to the list.

### Why
I first found your list and was a bit sad that there's no Ruby QR code library. A couple of days later I stumbled upon rqrcode. I had it set up on a brink and had my QR codes in less than ten minutes. I think it's a powerful and simple to use resource.