### PR TITLE
Add SnapAPI QR code generation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ that the library allows to generate QR codes.
 - [BaconQRCode `W`](https://github.com/Bacon/BaconQRCode) - QR code generator for PHP.
 
 
+## API
+
+- [SnapAPI `W`](https://api-snap.com/docs) - REST API for generating QR codes from text, URLs, or arbitrary data. Returns PNG images. Part of a bundled utility API service.
+
 ## Resources
 
 - [zxing](https://github.com/zxing/zxing/wiki/Barcode-Contents) - QR code payload format catalog.


### PR DESCRIPTION
Added SnapAPI to a new API section.

[SnapAPI](https://api-snap.com) provides a REST API for generating QR codes from text, URLs, or arbitrary data, returning PNG images. It includes an OpenAPI spec and a free tier (100 requests/month).

Docs: https://api-snap.com/docs