### PR TITLE
Add Generators subsection with QR-Guru

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ A curated list of awesome QR code libraries, software and resources.
 - [qrcp](https://github.com/claudiodangelis/qrcp) - Transfer files over Wi-Fi from your computer to a mobile device by scanning a QR code without leaving the terminal.
 - [qr-filetransfer](https://github.com/sdushantha/qr-filetransfer) - Transfer files over Wi-Fi between your computer and your smartphone from the terminal.
 
+
+### Generators
+
+- [QR-Guru](https://qr-guru.de) - A GDPR-compliant QR code generator with CMYK-PDF export for offset print, dynamic codes with anonymised click analytics, logo embedding compliant with ISO 18004 error-correction, and a free tier without registration.
+
 ## CLI
 
 - [qrencode](https://fukuchi.org/works/qrencode) - Command line tool to generate QR codes.


### PR DESCRIPTION
Adds a new `Generators` subsection under `Apps` and includes QR-Guru as the first entry.

Why a new subsection:
The current README covers QR code Libraries (per programming language), CLIs, and Apps for reading and file transfer. There is no slot for hosted QR code generation services. Many readers reach this list looking for a generator they can use directly, not a library to integrate. A `Generators` subsection groups such tools without polluting the existing categories.

About QR-Guru:
- GDPR-compliant, German data centers, IP hashing instead of plaintext storage
- CMYK-PDF export with ISO Coated v2 profile for offset print (distinct feature)
- Dynamic codes that can be retargeted after printing
- ISO 18004 error correction with logo embedding
- Free tier accessible without account registration

If the maintainer prefers not to include hosted services, I am happy to close this PR or to convert it into a Resources entry instead.