### PR TITLE
Add Mini-Tools.uk QR Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ A curated list of awesome QR code libraries, software and resources.
 ## Apps
 
 ### Readers
+### Generators
+
+- [Mini-Tools.uk QR Generator](https://mini-tools.uk/qr) - Self-recommending a browser QR code generator for URL, Wi-Fi, email and vCard/contact QR codes, with error correction options and PNG download.
+
 
 - [Web App](https://github.com/gokulkrishh/qrcodescan.in) - A progressive web application to scan QR codes.
 


### PR DESCRIPTION
Hi, self-recommending a single QR generator page I maintain: https://mini-tools.uk/qr

It fits as an app/generator rather than a library: it creates URL, Wi-Fi, email and vCard/contact QR codes in the browser and exports PNG. I avoided linking the broader Mini-Tools site.