### PR TITLE
Add qr-multi-imgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A curated list of awesome QR code libraries, software and resources.
 - [qrap](https://github.com/make-github-pseudonymous-again/qrap) - Generate a QR code payload for Wi-Fi access point credentials.
 - [spqr](https://github.com/make-github-pseudonymous-again/spqr) - Generate a QR code payload for initiating a SEPA transfer.
 - [qrscan](https://github.com/sayanarijit/qrscan) - Scan a QR code in the terminal using the system camera or a given image.
+- [qr-multi-imgs](https://github.com/thousandflowers/qr-multi-imgs) - Batch-scan a folder of images from a terminal TUI, then organize, export, and regenerate the codes.
 - [qrcode.show](https://qrcode.show) - Generate QR codes using curl.
 
 ## Libraries


### PR DESCRIPTION
Adds [qr-multi-imgs](https://github.com/thousandflowers/qr-multi-imgs) to the **CLI** section (next to `qrscan`).

**Why it's awesome**
- Batch-scans an entire **folder** of images from an interactive terminal TUI — most CLI scanners handle one image at a time.
- **Pure Go, zero CGo, zero system dependencies** (no `zbar`/`zbarimg`) — `go install` and run.
- **100% detection (3332/3332)** on the [lovasoa/qrcode-dataset](https://github.com/lovasoa/qrcode-dataset) damaged/distorted stress set, ~7s on an M2 Pro.
- Organize, export (JSON/CSV/TXT), and regenerate codes (PNG/JPG/SVG) from the same UI.
- MIT, cross-platform (macOS/Linux/Windows), CI + tagged releases.

Format check: one item, `https` link, alphabetically grouped with the other scanners, description does not mention "QR code" (implied).
