### PR TITLE
Add Qranite

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ A curated list of awesome QR code libraries, software and resources.
 
 - [Web App](https://github.com/gokulkrishh/qrcodescan.in) - A progressive web application to scan QR codes.
 
+### Generators
+
+- [Qranite](https://qranite.com) - Free in-browser generator with no signup, no watermark, and no expiry; paid dynamic short links with scan analytics.
+
 ### File Transfer
 
 - [qrcp](https://github.com/claudiodangelis/qrcp) - Transfer files over Wi-Fi from your computer to a mobile device by scanning a QR code without leaving the terminal.


### PR DESCRIPTION
Adds [Qranite](https://qranite.com) under a new **Generators** subsection in Apps (the list has Readers and File Transfer apps, but no online generator apps yet — qrcode.show is CLI-only).

Why it's awesome: generation happens entirely in the browser (qr-code-styling), so Wi-Fi passwords and contact details never touch a server, there is no signup, no watermark, and nothing that can expire — the structural opposite of the trial-trap generators. SVG and PNG up to 4096px, logos, colors, and dot styles included. Disclosure: I built it.

Follows the guidelines: one link, https, description ends with a period, no 'QR code' in the description, `npm run lint` passes on the entry (the two remaining lint errors are the missing 'awesome' GitHub topics on my fork, not content issues).